### PR TITLE
Updating init-container dep to the newest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt -y install senzingapi \
 
 # Initialize files.
 
-COPY --from=senzing/init-container:1.5.5  "/app/init-container.py" "/app/init-container.py"
+COPY --from=senzing/init-container:1.6.9  "/app/init-container.py" "/app/init-container.py"
 RUN /app/init-container.py initialize-files
 
 # Finally, make the container a non-root container again.


### PR DESCRIPTION
Updating init-container dependency to 1.6.9

## Which issue does this address

Issue number: #18 

## Why was change needed

Pointing to an old/incompatible version